### PR TITLE
Make the deadsnakes GPG key task idempotent

### DIFF
--- a/roles/python311/tasks/Ubuntu.yaml
+++ b/roles/python311/tasks/Ubuntu.yaml
@@ -1,9 +1,42 @@
 - name: Deadsnakes GPG key
-  ansible.builtin.get_url:
-    url: |-
-      https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776
+  ansible.builtin.copy:
+    # below the contents from
+    # https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776
+    # are stored inline because the order of the two lines starting Comment:
+    # and Version: is not stable across requests
     dest: /etc/apt/keyrings/deadsnakes.asc
     mode: "0o644"
+    content: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      Comment: Hostname:
+      Version: Hockeypuck 2.2
+
+      xsFNBFl8fYEBEADQmGZ6pDrwY9iH9DVlwNwTOvOZ7q7lHXPl/TLfMs1tckMc/D9a
+      hsdBN9VWtMmo+RySvhkIe8X15r65TFs2HE8ft6j2e/4K472pObM1hB+ajiU/wYX2
+      Syq7DBlNm6YMP5/SyQzRxqis4Ja1uUjW4Q5/Csdf5In8uMzXj5D1P7qOiP2aNa0E
+      r3w6PXWRTuTihWZOsHv8npyVYDBRR6gEZbd3r86snI/7o8Bfmad3KjbxL7aOdNMw
+      AqQFaNKl7Y+UJpv1CNFIf+twcOoC0se1SrsVJlAH9HNHM7XGQsPUwpNvQlcmvr+t
+      1vVS2m72lk3gyShDuJpi1TifGw+DoTqu54U0k+0sZm4pnQVeiizNkefU2UqOoGlt
+      4oiG9nIhSX04xRlGes3Ya0OjNI5b1xbcYoR+r0c3odI+UCw3VSZtKDX/xlH1o/82
+      b8ouXeE7LA1i4DvGNj4VSvoxv4ggIznxMf+PkWXWKwRGsbAAXF52rr4FUaeaKoIU
+      DkJqHXAxrB3PQslZ+ZgBEukkQZF76NkqRqP1E7FXzZZMo2eEL7vtnhSzUlanOf42
+      ECBoWHVoZQaRFMNbGpqlg9aWedHGyetMStS3nH1sqanr+i4I8VR/UH+ilarPTW3T
+      E0apWlsH8+N3IKbRx2wgrRZNoQEuyVtvyewDFYShJB3Zxt7VCy67vKAl1QARAQAB
+      zRxMYXVuY2hwYWQgUFBBIGZvciBkZWFkc25ha2VzwsF4BBMBAgAiBQJZfH2BAhsD
+      BgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRC6aTI2anVXdvwhD/4oI3yckeKn
+      9aJNNTJsyw4ydMkIAOdG+jbZsYv/rN73UVQF1RA8HC71SDmbd0Nu80koBOX+USuL
+      vvhoMIsARlD5dLx5f/zaQcYWJm/BtsMF/eZ4s1xsenwW6PpXd8FpaTn1qtg/8+O9
+      99R4uSetAhhyf1vSRb/8U0sgSQd38mpZZFq352UuVisXnmCThj621loQubYJ3lwU
+      LSLs8wmgo4XIYH7UgdavV9dfplPh0M19RHQL3wTyQP2KRNRq1rG7/n1XzUwDyqY6
+      eMVhdVhvnxAGztvdFCySVzBRr/rCw6quhcYQwBqdqaXhz63np+4mlUNfd8Eu+Vas
+      b/tbteF/pDu0yeFMpK4X09Cwn2kYYCpq4XujijW+iRWb4MO3G8LLi8oBAHP/k0CM
+      /QvSRbbG8JDQkQDH37Efm8iE/EttJTixjKAIfyugmvEHfcrnxaMoBioa6h6McQrM
+      vI8bJirxorJzOVF4kY7xXvMYwjzaDC8G0fTA8SzQRaShksR3USXZjz8vS6tZ+YNa
+      mRHPoZ3Ua0bz4t2aCcu/fknVGsXcNBazNIK9WF2665Ut/b7lDbojXsUZ3PpuqOoe
+      GQL9LRj7nmCI6ugoKkNp8ZXcGJ8BGw37Wep2ztyzDohXp6f/4mGgy2KYV9R4S8D5
+      yBDUU6BS7Su5nhQMStfdfr4FffLmnvFC9w==
+      =s7P2
+      -----END PGP PUBLIC KEY BLOCK-----
   become: true
 - name: Deadsnakes repository
   ansible.builtin.apt_repository:


### PR DESCRIPTION
Command to request the key ten times:

    seq 10 | while read i ; do curl --output $i.asc 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776'  ; done

Sometimes the first three lines are:

    -----BEGIN PGP PUBLIC KEY BLOCK-----
    Comment: Hostname:
    Version: Hockeypuck 2.2

And other times the first three lines are:

    -----BEGIN PGP PUBLIC KEY BLOCK-----
    Version: Hockeypuck 2.2
    Comment: Hostname:
